### PR TITLE
Pass REG_ENHANCED to regcomp where available

### DIFF
--- a/archivemount.c
+++ b/archivemount.c
@@ -421,7 +421,12 @@ build_tree(const char *mtpt)
 		}
 		strcpy(subtree_filter, PREFIX);
 		subtree_filter = strcat(subtree_filter, options.subtree_filter);
+		/* \? is only a special char on Mac if REG_ENHANCED is specified  */
+#if defined REG_ENHANCED
+		regex_error = regcomp(&subtree, subtree_filter, REG_ENHANCED);
+#else
 		regex_error = regcomp(&subtree, subtree_filter, 0);
+#endif
 		if (regex_error) {
 			regerror(regex_error, &subtree, error_buffer, 256);
 			log("Regex build error: %s\n", error_buffer);


### PR DESCRIPTION
On MacOS `-o subtree=<regexp>` currently fails as  `\?` only has a special meaning if the REG_ENHANCED flag is passed to regcomp.