### PR TITLE
Add AM_PROG_CC_C_O macro to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@
 AC_INIT([archivemount],[0.8.12], [andrel@cybernoia.de])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
+AM_PROG_CC_C_O
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile archivemount.1])


### PR DESCRIPTION
This macro checks that the C compiler supports the -c and -o
options together, which is needed to run autoreconf -i on a git clone.

This macro is needed only for automake <1.14, but add it for
compatibility with older environments, such as CentOS 7.
