### PR TITLE
fix compile error with gcc-9.2.1

### DIFF
--- a/archivemount.c
+++ b/archivemount.c
@@ -2791,7 +2791,6 @@ void setEcho(int echo)
 /* This is basically getline(3), re-implemented to avoid requiring
  * _POSIX_C_SOURCE >= 200809L. */
 ssize_t getLine(char **lineptr, size_t *n, FILE *stream) {
-	const int delim = '\n';
 	int can_realloc = 0;
 	ssize_t count = 0;
 	if (*lineptr == NULL && *n == 0) {
@@ -2814,9 +2813,9 @@ ssize_t getLine(char **lineptr, size_t *n, FILE *stream) {
 		int c = fgetc(stream);
 		switch (c) {
 			default:    (*lineptr)[count++] = c;    break;
-			case delim: (*lineptr)[count++] = c;    /* fall through */
+			case '\n':  (*lineptr)[count++] = c;    /* fall through */
 			case EOF:   (*lineptr)[count]   = '\0';
-			            return (c == delim || feof(stream)) ? count : -1;
+			            return (c == '\n' || feof(stream)) ? count : -1;
 		}
 	}
 }


### PR DESCRIPTION
Fedora Rawhide (upcoming Fedora 33) has gcc-9.2.1 which causes compiling
archivemount to fail with the following error:

    archivemount.c: In function ‘getLine’:
    archivemount.c:2817:4: error: case label does not reduce to an integer constant
     2817 |    case delim: (*lineptr)[count++] = c;    /* fall through */
          |    ^~~~

The 'delim' integer constant for the switch statement should be a
compile time constant, so either hard-coded or #define'd.