### PR TITLE
do not wipe CFLAGS in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,6 @@ AC_CONFIG_FILES([Makefile archivemount.1])
 RELEASE_DATE="19 April 2020"
 AC_SUBST(RELEASE_DATE)
 
-CFLAGS=
-
 # Check for libfuse
 PKG_CHECK_EXISTS(fuse)
 PKG_CHECK_MODULES([FUSE], [fuse >= 2.6],,


### PR DESCRIPTION
When extra CFLAGS are passed in the environement for ./configure, these
are expected to be used while compiling. By setting `CFLAGS=` to an
empty value in configure.ac, distribution specific CLFAGS will not be
available anymore.

This caused linking issues on Fedora as it tries to compile with extra
hardening flags.